### PR TITLE
fix(ai): correct image URL path for generated images

### DIFF
--- a/src/services/conversationService.js
+++ b/src/services/conversationService.js
@@ -145,10 +145,10 @@ class ConversationService {
                                 const buffer = Buffer.from(inlineData.data, 'base64');
                                 const mimeType = inlineData.mimeType;
                                 
-                                const filename = `${threadId}_${Date.now()}.png`;
-                                const uploadResult = await uploadUserAsset(userId, buffer, mimeType, 'threads', filename);
+                                const filename = `${Date.now()}.png`;
+                                const uploadResult = await uploadUserAsset(userId, buffer, mimeType, `threads/${threadId}/images`, filename);
                                 
-                                const markdownImage = `\n\n![Generated Image](${uploadResult.publicUrl})\n\n`;
+                                const markdownImage = `\n\n![Generated Image](${uploadResult.url})\n\n`;
                                 fullResponse += markdownImage;
                                 yield markdownImage;
                             } else {


### PR DESCRIPTION
## Description
Fixes the issue where generated images were being uploaded directly to `threads/` instead of being nested under their respective `threadId`.

## Changes
- Updated `ConversationService.streamReply` to pass `threads/${threadId}/images` to `uploadUserAsset`.

Closes #45