### PR TITLE
feat(user): profile media management and expanded fields

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -201,6 +201,84 @@ const activateUser = async (req, res) => {
     }
 };
 
+/**
+ * Update Profile Picture
+ */
+const updateProfilePicture = async (req, res) => {
+    try {
+        const { uid } = req.user;
+        if (!req.file) throw new Error('No image file provided');
+
+        const updatedUser = await userService.updateProfilePicture(
+            uid,
+            req.file.buffer,
+            req.file.mimetype
+        );
+
+        res.json({ success: true, data: updatedUser });
+    } catch (error) {
+        res.status(400).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * Update Cover Photo
+ */
+const updateCoverPhoto = async (req, res) => {
+    try {
+        const { uid } = req.user;
+        if (!req.file) throw new Error('No image file provided');
+
+        const updatedUser = await userService.updateCoverPhoto(
+            uid,
+            req.file.buffer,
+            req.file.mimetype
+        );
+
+        res.json({ success: true, data: updatedUser });
+    } catch (error) {
+        res.status(400).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * Add Asset to Gallery
+ */
+const addGalleryAsset = async (req, res) => {
+    try {
+        const { uid } = req.user;
+        const metadata = req.body;
+        if (!req.file) throw new Error('No file provided');
+
+        const updatedUser = await userService.addGalleryAsset(
+            uid,
+            req.file.buffer,
+            req.file.mimetype,
+            metadata
+        );
+
+        res.json({ success: true, data: updatedUser });
+    } catch (error) {
+        res.status(400).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * Delete Asset from Gallery
+ */
+const deleteGalleryAsset = async (req, res) => {
+    try {
+        const { uid } = req.user;
+        const { assetUrl } = req.body;
+        if (!assetUrl) throw new Error('Asset URL is required');
+
+        const updatedUser = await userService.deleteGalleryAsset(uid, assetUrl);
+        res.json({ success: true, data: updatedUser });
+    } catch (error) {
+        res.status(400).json({ success: false, error: error.message });
+    }
+};
+
 export {
     onboardUser,
     getMe,
@@ -209,5 +287,9 @@ export {
     getAllUsers,
     deactivateUser,
     disableUser,
-    activateUser
+    activateUser,
+    updateProfilePicture,
+    updateCoverPhoto,
+    addGalleryAsset,
+    deleteGalleryAsset
 };

--- a/src/models/userProfileModel.js
+++ b/src/models/userProfileModel.js
@@ -23,6 +23,10 @@ const userProfileSchema = {
         type: String,
         trim: true
     },
+    coverURL: {
+        type: String,
+        trim: true
+    },
     occupation: {
         type: String,
         trim: true
@@ -32,6 +36,22 @@ const userProfileSchema = {
         maxlength: 1000,
         trim: true
     },
+    skills: {
+        type: Array,
+        default: []
+    },
+    expertise: {
+        type: Array,
+        default: [] // Areas the user is knowledgeable in
+    },
+    gallery: {
+        type: Array, // Array of { url, type: 'photo'|'video', title, createdAt }
+        default: []
+    },
+    featured: {
+        type: Array, // Array of { type: 'article'|'image'|'video', id, title, url }
+        default: []
+    },
     hobbies: {
         type: Array,
         default: []
@@ -39,10 +59,6 @@ const userProfileSchema = {
     interests: {
         type: Array,
         default: []
-    },
-    expertise: {
-        type: Array,
-        default: [] // Areas the user is knowledgeable in
     },
     writingStyle: {
         type: String,

--- a/src/routes/userProfile.js
+++ b/src/routes/userProfile.js
@@ -132,6 +132,89 @@ router.patch('/me',
 
 /**
  * @swagger
+ * /users/me/photo:
+ *   patch:
+ *     summary: Update profile picture
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ */
+router.patch('/me/photo', upload.single('file'), userController.updateProfilePicture);
+
+/**
+ * @swagger
+ * /users/me/cover:
+ *   patch:
+ *     summary: Update cover photo
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ */
+router.patch('/me/cover', upload.single('file'), userController.updateCoverPhoto);
+
+/**
+ * @swagger
+ * /users/me/gallery:
+ *   post:
+ *     summary: Add asset to gallery
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ */
+router.post('/me/gallery', upload.single('file'), userController.addGalleryAsset);
+
+/**
+ * @swagger
+ * /users/me/gallery:
+ *   delete:
+ *     summary: Remove asset from gallery
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               assetUrl:
+ *                 type: string
+ */
+router.delete('/me/gallery', userController.deleteGalleryAsset);
+
+/**
+ * @swagger
  * /users/{id}:
  *   get:
  *     summary: Get user by ID

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -1,5 +1,6 @@
 import { User } from '../models/index.js';
 import logger from '../utils/logger.js';
+import * as storageService from './storageService.js';
 
 /**
  * Create a new user profile
@@ -192,6 +193,109 @@ async function listUsers(query = {}, options = {}) {
     );
 }
 
+/**
+ * Update user's profile picture
+ * @param {string} uid 
+ * @param {Buffer} fileBuffer 
+ * @param {string} mimeType 
+ */
+async function updateProfilePicture(uid, fileBuffer, mimeType) {
+    const user = await getUser(uid);
+    if (!user) throw new Error('User not found');
+
+    const filename = `profile_${Date.now()}.${mimeType.split('/')[1]}`;
+    const uploadResult = await storageService.uploadUserAsset(
+        user.uid,
+        fileBuffer,
+        mimeType,
+        'profile',
+        filename
+    );
+
+    return await updateUser(uid, { photoURL: uploadResult.url });
+}
+
+/**
+ * Update user's cover photo
+ * @param {string} uid 
+ * @param {Buffer} fileBuffer 
+ * @param {string} mimeType 
+ */
+async function updateCoverPhoto(uid, fileBuffer, mimeType) {
+    const user = await getUser(uid);
+    if (!user) throw new Error('User not found');
+
+    const filename = `cover_${Date.now()}.${mimeType.split('/')[1]}`;
+    const uploadResult = await storageService.uploadUserAsset(
+        user.uid,
+        fileBuffer,
+        mimeType,
+        'profile',
+        filename
+    );
+
+    return await updateUser(uid, { coverURL: uploadResult.url });
+}
+
+/**
+ * Add an asset to the user's gallery
+ * @param {string} uid 
+ * @param {Buffer} fileBuffer 
+ * @param {string} mimeType 
+ * @param {Object} metadata { title, description, type: 'photo'|'video' }
+ */
+async function addGalleryAsset(uid, fileBuffer, mimeType, metadata = {}) {
+    const user = await getUser(uid);
+    if (!user) throw new Error('User not found');
+
+    const fileType = metadata.type || (mimeType.startsWith('video') ? 'video' : 'photo');
+    const filename = `gallery_${Date.now()}.${mimeType.split('/')[1]}`;
+    
+    const uploadResult = await storageService.uploadUserAsset(
+        user.uid,
+        fileBuffer,
+        mimeType,
+        'gallery',
+        filename
+    );
+
+    const newAsset = {
+        url: uploadResult.url,
+        type: fileType,
+        title: metadata.title || '',
+        description: metadata.description || '',
+        createdAt: new Date()
+    };
+
+    const updatedGallery = [...(user.gallery || []), newAsset];
+    return await updateUser(uid, { gallery: updatedGallery });
+}
+
+/**
+ * Remove an asset from the user's gallery
+ * @param {string} uid 
+ * @param {string} assetUrl 
+ */
+async function deleteGalleryAsset(uid, assetUrl) {
+    const user = await getUser(uid);
+    if (!user) throw new Error('User not found');
+
+    // 1. Delete from storage if it's our storage
+    if (assetUrl.includes('storage.googleapis.com')) {
+        try {
+            const urlObj = new URL(assetUrl);
+            const path = urlObj.pathname.split('/').slice(2).join('/');
+            await storageService.deleteFile(path);
+        } catch (e) {
+            logger.warn(`Failed to delete gallery file from storage: ${assetUrl}`);
+        }
+    }
+
+    // 2. Remove from database
+    const updatedGallery = (user.gallery || []).filter(item => item.url !== assetUrl);
+    return await updateUser(uid, { gallery: updatedGallery });
+}
+
 export {
     createUser,
     getUser,
@@ -202,5 +306,9 @@ export {
     deleteUserById,
     updateLastActive,
     isDisplayNameTaken,
-    listUsers
+    listUsers,
+    updateProfilePicture,
+    updateCoverPhoto,
+    addGalleryAsset,
+    deleteGalleryAsset
 };


### PR DESCRIPTION
## Description
This PR enhances the user profile system by adding support for media management (profile pictures, cover photos, and gallery) and expanding the profile schema to include more professional and personal details.

## Key Changes
- **Model**: Added `coverURL`, `skills`, `gallery`, and `featured` to the `User` schema.
- **Service**: Implemented `updateProfilePicture`, `updateCoverPhoto`, `addGalleryAsset`, and `deleteGalleryAsset` in `userProfileService`.
- **Controller**: Added new methods to `userProfileController` to handle media uploads and management.
- **Routes**: Exposed new endpoints:
    - `PATCH /me/photo`: Update profile picture.
    - `PATCH /me/cover`: Update cover photo.
    - `POST /me/gallery`: Add image/video to gallery.
    - `DELETE /me/gallery`: Remove asset from gallery.

## Testing
- Verified schema updates in Firestore.
- Tested media uploads via Postman (multipart/form-data).
- Verified storage isolation under `users/<userId>/profile/` and `users/<userId>/gallery/`.