### PR TITLE
fix(book): correctly extract 'type' and pass arguments to createBook

### DIFF
--- a/src/controllers/bookController.js
+++ b/src/controllers/bookController.js
@@ -6,10 +6,10 @@ class BookController {
      */
     async createBook(req, res) {
         try {
-            const { title, description, threadId } = req.body;
+            const { title, description, threadId, type } = req.body;
             const userId = req.user.uid;
             
-            const book = await bookService.createBook(userId, title, description, threadId);
+            const book = await bookService.createBook(userId, title, description, type, threadId);
             
             res.status(201).json({
                 success: true,


### PR DESCRIPTION
## Description
This PR fixes a validation error in the book creation process. Previously, the 'type' parameter was incorrectly receiving the 'threadId' because of a mismatch between the controller's argument extraction and the service's method signature.

## Changes
- Updated 'src/controllers/bookController.js' to extract 'type' from 'req.body'.
- Corrected the argument order in the call to 'bookService.createBook(userId, title, description, type, threadId)'.

## Validation
- Verified that the 'type' field in the service now correctly receives either 'book' or 'paper' instead of a UUID/threadId.
- Ensured that the 'threadId' is now correctly passed as the fifth argument.